### PR TITLE
Dev/testing timeouts

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -4,6 +4,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -2,9 +2,10 @@ name: Test
 on: [push, pull_request]
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]
     environment:
       name: Test

--- a/eopsin/tests/unit/binance_test.py
+++ b/eopsin/tests/unit/binance_test.py
@@ -2,11 +2,11 @@ import datetime
 import os
 import unittest
 
+import func_timeout
 import numpy as np
 import sqlalchemy as sql
 
 import eopsin as eop
-from eopsin.tests.unit.timeout import timeout
 
 
 class TestBinanceBasic(unittest.TestCase):
@@ -43,7 +43,7 @@ class TestBinanceBasic(unittest.TestCase):
         now = datetime.datetime.now().astimezone(datetime.timezone.utc)
         self.assertLess(np.abs((serverTime - now).total_seconds()), 1)
 
-    @timeout(seconds=70)
+    @func_timeout.func_set_timeout(70)
     def test_minuteTrigger(self):
         class TriggerMinuteOnce:
             def __init__(self):

--- a/eopsin/tests/unit/binance_test.py
+++ b/eopsin/tests/unit/binance_test.py
@@ -4,9 +4,9 @@ import unittest
 
 import numpy as np
 import sqlalchemy as sql
-import timeout_decorator
 
 import eopsin as eop
+from eopsin.tests.unit.timeout import timeout
 
 
 class TestBinanceBasic(unittest.TestCase):
@@ -43,7 +43,7 @@ class TestBinanceBasic(unittest.TestCase):
         now = datetime.datetime.now().astimezone(datetime.timezone.utc)
         self.assertLess(np.abs((serverTime - now).total_seconds()), 1)
 
-    @timeout_decorator.timeout(seconds=70, use_signals=False)
+    @timeout(seconds=70)
     def test_minuteTrigger(self):
         class TriggerMinuteOnce:
             def __init__(self):

--- a/eopsin/tests/unit/binance_test.py
+++ b/eopsin/tests/unit/binance_test.py
@@ -43,7 +43,7 @@ class TestBinanceBasic(unittest.TestCase):
         now = datetime.datetime.now().astimezone(datetime.timezone.utc)
         self.assertLess(np.abs((serverTime - now).total_seconds()), 1)
 
-    @timeout_decorator.timeout(70)
+    @timeout_decorator.timeout(seconds=70, use_signals=False)
     def test_minuteTrigger(self):
         class TriggerMinuteOnce:
             def __init__(self):

--- a/eopsin/tests/unit/timeout.py
+++ b/eopsin/tests/unit/timeout.py
@@ -1,0 +1,52 @@
+import multiprocessing as mp
+
+
+class TimeoutException(Exception):
+    pass
+
+
+class InterruptableProcess(mp.Process):
+    def __init__(self, func, *args, **kwargs):
+        super().__init__()
+        self._func = func
+        self._args = args
+        self._kwargs = kwargs
+        self._result = None
+
+    def run(self):
+        self._result = self._func(*self._args, **self._kwargs)
+
+    @property
+    def result(self):
+        return self._result
+
+
+class timeout:
+    def __init__(self, seconds=10):
+        self._sec = seconds
+
+    def __call__(self, f):
+        def wrapped_f(*args, **kwargs):
+            it = InterruptableProcess(f, *args, **kwargs)
+            it.start()
+            it.join(self._sec)
+            if not it.is_alive():
+                return it.result
+            else:
+                it.terminate()
+                raise TimeoutException(f'Execution time of {self._sec} seconds exceeded')
+
+        return wrapped_f
+
+
+if __name__ == '__main__':
+    import time
+
+
+    @timeout(2)
+    def f(seconds):
+        time.sleep(seconds)
+        return 'finished'
+
+
+    print(f(1))

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ regex==2021.4.4
 requests==2.25.1
 six==1.16.0
 SQLAlchemy==1.4.15
-timeout-decorator==0.5.0
 typing-extensions==3.10.0.0
 tzlocal==2.1
 ujson==4.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 aiohttp==3.7.4.post0
-async-timeout==3.0.1
 attrs==21.2.0
 certifi==2020.12.5
 chardet==4.0.0
 dateparser==1.0.0
+func_timeout==4.3.5
 greenlet==1.1.0
 idna==2.10
 multidict==5.1.0


### PR DESCRIPTION
Fixing an issue regarding unittest timeouts
 - The previously used `timeout_decorator` decorator package relies on `SIGALARM`, which causes problems on windows
 - Switching to the package `func_timeout` seems to work as intended and solve the issue